### PR TITLE
Clear two columns at a time to prevent rendering artifacts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ impl Bats {
 
             if pos != end_pos {
                 cursor.goto(pos, y_position).unwrap();
-                terminal.write(" ").unwrap();
+                terminal.write("  ").unwrap();
             }
         }
 


### PR DESCRIPTION
I tried out bats in Halloween mode, but was getting rendering artifacts for the spiderweb emoji:
![](https://i.imgur.com/hAmd9FG.png)

This is a bug in my terminal's emoji renderer (maybe other gnome-based terminals will have similar artifacts?). It was easy to fix in bats by writing 2 spaces instead of 1 when clearing emojis while animating:
![](https://i.imgur.com/BY1xjjG.png)